### PR TITLE
Explicitly set column classes

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -56,16 +56,64 @@ get_sub_folders <- function(tidy_folder) {
 ## and merges them according to sheet number
 ## the function returns one merged csv for each file 
 
-merge_subfolder <- function(sub_folder) {
-  print(paste0("processing ", sub_folder))
-  csv_files <- list.files(sub_folder, pattern = "*.csv", full.names = TRUE) %>% 
-    lapply(function(file){
-      read.csv(file = file, header = TRUE,  check.names = FALSE)
-    }) 
-  big_object <- do.call(plyr::rbind.fill, csv_files)
-  return(big_object)
+merge_subfolder_ind <- function(sub_folder) {
+  
+  message(paste0("processing ", sub_folder))
+  
+  ## Handle '1' type files with different cols and classes
+  if(basename(sub_folder) == '1') {
+    list.files(sub_folder, pattern = "*.csv", full.names = TRUE) %>%
+      map_df(~ {
+        print(.x)
+        readr::read_csv(
+          .x,
+          col_types = cols(
+            year = col_double(),
+            cityid = col_double(),
+            `postal|area` = col_character(),
+            `postal|walk` = col_character(),
+            `level|of|geo` = col_double(),
+            `place|name|geo` = col_character(),
+            .default = col_double()),
+          na = c("", "NA", "X")
+        )
+      })
+  } else {
+    list.files(sub_folder, pattern = "*.csv", full.names = TRUE) %>%
+      map_df(~ {
+        print(.x)
+        readr::read_csv(
+          .x,
+          col_types = cols(
+            `postal|area` = col_character(),
+            `postal|walk` = col_character(),
+            `place|name` = col_character(),
+            .default = col_double()
+          ),
+          na = c("", "NA", "X")
+        )
+      })
+  }
+
 }
 
+
+merge_subfolder_fam <- function(sub_folder) {
+  list.files(sub_folder, pattern = "*.csv", full.names = TRUE) %>%
+    map_df(~ {
+      print(.x)
+      readr::read_csv(
+        .x,
+        col_types = cols(
+          `postal|area` = col_character(),
+          `postal|walk` = col_character(),
+          `place|name` = col_character(),
+          .default = col_double()
+        ),
+        na = c("", "NA", "X")
+      )
+    })
+}
 
 #-------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The scripts in this repository tidy purchased anonymized annual Statistics Canad
 
 #### Raw Data
 
-The source .xls files per year (or per table in the case of Individual Table 13) for anonymized individual and family income tax data must be manually placed in the appropriate subfolders: `/data-raw/fam`, `/data-raw/ind`, and `/data-raw/ind13`.
+The source .xls files per year (or per table in the case of Individual Table 13) for anonymized individual and family income tax data must be manually placed in the appropriate subfolders: `/data-raw/fam`, `/data-raw/ind`, and `/data-raw/ind13`. Table 13 is being handled individually to accomodate a diversity of data structures. 
 
 #### Code
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # statscan-taxdata-tidying
  
-A set of R scripts to read, tidy, merge & write de-identified annual Statistics Canada income tax data for British Columbia. 
+A set of R scripts to read, tidy, merge & write aggregated annual Statistics Canada income tax data for British Columbia. 
 
-The scripts in this repository tidy de-identified annual Statistics Canada data similar to ['Tax filers and dependants with income by source of income' Table: 11-10-0007-01](https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid=1110000701). The annual data are provided as sheets in .xls format under the [Statistics Canada Open Licence](https://www.statcan.gc.ca/eng/reference/licence), one .xls file for each year for de-identified individuals and families. The Technical Reference Guide for the Annual Income Estimates for Census Families, Individuals and Seniors is available on the Statistics Canada website:
+The scripts in this repository tidy aggregated annual Statistics Canada data similar to ['Tax filers and dependants with income by source of income' Table: 11-10-0007-01](https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid=1110000701). The aggregated annual data are provided as sheets in .xls format under the [Statistics Canada Open Licence](https://www.statcan.gc.ca/eng/reference/licence), one .xls file per year for aggregated individual tables and aggregated family tables. The Technical Reference Guide for the Annual Income Estimates for Census Families, Individuals and Seniors is available on the Statistics Canada website:
 [T1 Family File, Final Estimates, 2016](
 https://www150.statcan.gc.ca/n1/pub/72-212-x/72-212-x2018001-eng.htm).
 
@@ -13,17 +13,17 @@ https://www150.statcan.gc.ca/n1/pub/72-212-x/72-212-x2018001-eng.htm).
 
 #### Raw Data
 
-The source .xls files per year (or per table in the case of Individual Table 13) for de-identified individual and family income tax data must be manually placed in the appropriate subfolders: `/data-raw/fam`, `/data-raw/ind`, and `/data-raw/ind13`. Table 13 is being handled individually to accomodate a diversity of data structures. 
+The source .xls files per year (or per table in the case of Individual Table 13) must be manually placed in the appropriate subfolders: `/data-raw/fam`, `/data-raw/ind`, and `/data-raw/ind13`. Table 13 is being handled individually to accomodate a diversity of data structures. 
 
 #### Code
 
-There are three core scripts that are required, they should to be run in order:
+There are three core scripts, one for each table type (Individuals, Families and Individual Table 13):
 
 - `fam-clean.R`
 - `ind-clean.R`
 - `ind-clean-13.R`
 
-The `run-all.R` script can be `source`ed to run the scripts all at once. The `setup.R` and `functions.R` scripts in the `/R` folder are sourced programatically.
+The `run-all.R` script should be `source`ed to run the scripts all at once. The `setup.R` and `functions.R` scripts in the `/R` folder are sourced programatically.
 
 All packages used in the analysis can be installed from CRAN using `install.packages()`.  
 
@@ -33,8 +33,7 @@ Tidied .CSV equivalent files for each Table&mdash;individuals and families&mdash
 
 #### Testing
 
-To test the integrity of data after tidying, the `test` scripts in test subfolder can be used. 
-These scripts contain code that compares the tidied outputs for individuals and families with the raw data, ensuring data cleanup does not  the change original files.  
+The `test` scripts in the `/test` subfolder can be used to test the integrity of the data after tidying. These scripts contain code that compares the tidied outputs for individuals and families with the raw data, ensuring data cleanup does not the change original files.  
 
 ## Getting Help or Reporting an Issue
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 # statscan-taxdata-tidying
  
-A set of R scripts to read, tidy, merge & write anonymized annual Statistics Canada income tax data for British Columbia. 
+A set of R scripts to read, tidy, merge & write de-identified annual Statistics Canada income tax data for British Columbia. 
 
-The scripts in this repository tidy purchased anonymized annual Statistics Canada data similar to ['Tax filers and dependants with income by source of income' Table: 11-10-0007-01](https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid=1110000701). The annual data are provided as sheets in .xls format under the [Statistics Canada Open Licence](https://www.statcan.gc.ca/eng/reference/licence), one .xls file for each year for anonymized individuals and anonymized families. Metadata provided by Statistics Canada is in `/docs` folder.
+The scripts in this repository tidy de-identified annual Statistics Canada data similar to ['Tax filers and dependants with income by source of income' Table: 11-10-0007-01](https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid=1110000701). The annual data are provided as sheets in .xls format under the [Statistics Canada Open Licence](https://www.statcan.gc.ca/eng/reference/licence), one .xls file for each year for de-identified individuals and families. The Technical Reference Guide for the Annual Income Estimates for Census Families, Individuals and Seniors is available on the Statistics Canada website:
+[T1 Family File, Final Estimates, 2016](
+https://www150.statcan.gc.ca/n1/pub/72-212-x/72-212-x2018001-eng.htm).
 
 
 ## Usage
 
 #### Raw Data
 
-The source .xls files per year (or per table in the case of Individual Table 13) for anonymized individual and family income tax data must be manually placed in the appropriate subfolders: `/data-raw/fam`, `/data-raw/ind`, and `/data-raw/ind13`. Table 13 is being handled individually to accomodate a diversity of data structures. 
+The source .xls files per year (or per table in the case of Individual Table 13) for de-identified individual and family income tax data must be manually placed in the appropriate subfolders: `/data-raw/fam`, `/data-raw/ind`, and `/data-raw/ind13`. Table 13 is being handled individually to accomodate a diversity of data structures. 
 
 #### Code
 
@@ -60,7 +62,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 ```
 
-This repository is maintained by [Data Science & Analytics Branch (OCIO) ](https://github.com/orgs/bcgov/teams/dsab).
+This repository is maintained by [Data Science Partnerships Team (OCIO) ](https://github.com/orgs/bcgov/teams/dsp).
 
 ---
 *This project was created using the [bcgovr](https://github.com/bcgov/bcgovr) package.* 

--- a/docs/statscan-tables.Rmd
+++ b/docs/statscan-tables.Rmd
@@ -3,71 +3,27 @@ title: "Income Tax Data Cleaning Project"
 author: ""
 ---
 
-# Introduction 
 
-Integrated Data Division (IDD, OCIO, CITZ) has acquired historical annual t1 tax data from BC Stats (JTT) who has in turn purchased the data tables from Statistics Canada.
+Digital Platforms & Data Division (OCIO, CITZ) R code to reformat aggregated annual t1 tax data tables from Statistics Canada, provided by BCStats (JEDC).
 
-The data comes in .xls format and are housed in the folder named data-raw.
+The data comes in .xls format and are housed in the folder named `data-raw`.
 
-In this project, the xls files are cleaned and merged into one csv sheet per table merging all years using R Statistical Software. 
+In this project, the .xls files are tidied and merged into one csv sheet per table merging all years using R. 
 
-For more questions, please consult with Director of Data Insights (Dan Mackenzie, Dan.Mackenzie@gov.bc.ca) or data scientists at IDD (Stephanie.Hazlitt@gov.bc.ca; Ashlin.Richardson@gov.bc.ca or Sam.Albers@gov.bc.ca; Noushin.Nabavi@gov.bc.ca). 
+The bcgov GitHub repository for this project can found here: https://github.com/bcgov/statscan-taxdata-tidying
 
-The BC Gov GitHub repository for this project can found here: https://github.com/bcgov/statscan-taxdata-tidying
-
-The technical Reference Guide for the Annual Income Estimates for Census Families, Individuals and Seniors can be found in the `/docs` folder. For information about this product or the wide range of services and data available from Statistics Canada, visit their [website](www.statcan.gc.ca).
+The Technical Reference Guide for the Annual Income Estimates for Census Families, Individuals and Seniors is available on the Statistics Canada website:
+[T1 Family File, Final Estimates, 2016](
+https://www150.statcan.gc.ca/n1/pub/72-212-x/72-212-x2018001-eng.htm). For information about this product or the wide range of services and data available from Statistics Canada, visit their [website](www.statcan.gc.ca).
 For further questions, the Statistics Canada email is <STATCAN.infostats-infostats.STATCAN@canada.ca>. 
 
-This data (from Statistics Canada) includes information copied with permission from Canada Post Corporation. Information about Statistics Canada Open Licence Grants can be found here: https://www.statcan.gc.ca/eng/reference/licence 
+This data (from Statistics Canada) includes information copied with permission from Canada Post Corporation. Information about Statistics Canada Open Licence can be found here: https://www.statcan.gc.ca/eng/reference/licence 
 
-# Data table structures for individuals and families
+### Data Tables for Individuals & Families
 
-Currently, the fully anonymized data includes income estimates for individuals for various geographical areas in B.C. ranging from years 2000 up to 2015. Income estimates for families range from years 2004 up to 2016. Each table is an aggregation of all years for that table.
-
-# Individual table structures 
-
-```{r echo= FALSE}
-library(knitr)
-library(kableExtra)
-Individuals <- data.frame(
-  # = 1:19,	
-  
-  Table_ID = c("Table I-01", "Table I-02", "Table I-3A", "Table I-3B", "Table I-3C", "Table I-04", "Table I-5A", "Table I-5B",
-            "Table I-5C", "Table I-06", "Table I-7A", "Table I-7B", "Table I-7C", "Table I-08", "Table I-09", "Table I-10",
-            "Table I-11", "Table I-12", "Table I-13"), 
-  
-  Table_Name = c("Taxfilers and dependents, summary table, income and demographics of individuals", "Taxfilers and dependents by sex, marital status and age groups", "Male taxfilers and dependents by single years of age", "Female taxfilers and dependents by single years of age", "Taxfilers and dependents by single year of age", "Taxfilers and dependents with income by source of income", "Male taxfilers and dependents with income by total Income and age groups", "Female taxfilers and dependents with income by total income and age groups", "Taxfilers and dependents with income by total income and age groups", "Taxfilers and dependents with income by sex, income taxes, selected deductions and benefits", "Male taxfilers and dependents with income by after-tax income and age groups", "Female taxfilers and dependents  with income by after-tax income and age groups", "Taxfilers and dependents with income by after-tax income and age groups", "Taxfilers and dependents with income by income taxes and after-tax income, sex and age groups", "Economic dependency profile of individuals", "Labour income profile of individuals", "Taxfilers and dependents 15 years of age and over with labour income by sex and age groups", "Taxfilers and dependents 15 years of age and over receiving employment insurance by age groups and sex", "After-tax low income status of tax filers and dependents, census family low income measure, for couple and lone parent families by family composition"),																																																																											
- stringsAsFactors = FALSE)
-``` 
+Currently, the data includes income estimates for individuals aggregated for various geographical areas in B.C. ranging from years 2000 up to 2015. Income estimates for families range from years 2004 up to 2016. Each table is an aggregation of all years for that table.
 
 
-```{r echo = FALSE}
-kable(cbind(Individuals), "latex", booktabs = T, caption = "Structure for Individual Tables") %>%
-  kable_styling(latex_options = c("striped", "scale_down", font_size=200))
-```
+### Data Tidying
 
-# Family table structures 
-
-```{r echo= FALSE}
-library(knitr)
-library(kableExtra)
-Family <- data.frame(
-  # = 1:26,	
-  
-  Table_ID = c("Table F-01", "Table F-02", "Table F-3A", "Table F-3B", "Table F-3C", "Table F-04A", "Table F-04B", "Table F-04C", "Table F-5A", "Table F-5B", "Table F-06", "Table F-7", "Table F-08", "Table F-09", "Table F-10", "Table F-11", "Table F-12", "Table F-13", "Table F-14A", "Table F-14B", "Table F-14C", "Table F-15", "Table F-17", "Table F-18", "Table F-19", "Table F-20"),
-  
-  Table_Name = c("Summary census family income table", "Taxfilers and dependents by age groups and census family type", "Couple families by age of older partner or parent and number of children", "Lone-Parent families by age of parent and number of children", "Census families by age of older partner or parent and number of children", "Distribution of total income by couple family and age of older partner or parent", "Distribution of total income by lone-parent family and age of parent", "Distribution of total income of persons not in census families by age of individual", "Couple families by total income and number of children", "Lone-Parent families by total income and number of children", "Sources of Income by census family Type", "Economic dependency profile of couple families", "Economic dependency profile of lone-parent families and persons not in census families", "Labour income profile of couple families", "Labour income profile of lone-parent families and persons not in census families", "Labour income by age group and sex", "Employment insurance by age group and sex", "Single-earner and dual-earner families by number of children, includes only partners, parents reporting non-negative employment income", "Couple families by percentage of wife's contribution to couple's employment income and by number of children", "Couple families by percentage of wife's contribution to husband/wife employment income and by age of wife", "Couple families by percentage of wife's contribution to husband, wife employment income and by family employment income range", "Census families with children by age of children and children by age groups", "Before-tax low income status, based on census family low income measures, family type and family composition", "After-tax low income status, based on census family low income measures, by family type and family composition", "After-tax low income status of census families, census family low income measures, by family type and family composition, adjusted methodology", "Census families by family type and family composition including before and after-tax median income of the family"),
-  
-  
- stringsAsFactors = FALSE)
-``` 
-
-# Data Tidying
-
-The data comes in messy format (empty cells, duplicate column names, table names in each sheet, nested tables, source declaration at end, etc). The individuals, individuals table 13, and families have various different formats and require their unique clean-up. The scripts are designed to preserve data integrity and work automatically in order to clean the tables in batches. We are also complying with Population Data BC's data intake requirements for generating the final merged csv tables. 
-
-
-```{r echo = FALSE}
-kable(cbind(Family), "latex", booktabs = T, caption = "Structure for Family Tables") %>%
-  kable_styling(latex_options = c("striped", "scale_down", font_size=200))
-```
+The .xls data format contains empty cells, duplicate column names, table names in each sheet, nested tables, source declaration at end, etc. The individuals, individuals table 13, and families have various different formats and require unique clean-up. The scripts are designed to preserve data integrity and work automatically in order to clean the tables in batches.

--- a/fam-clean.R
+++ b/fam-clean.R
@@ -56,7 +56,7 @@ tidy_tax_fam <- function(sheet, path, filter_BC = TRUE) {
       read_excel(sheet = sheet, skip = 1, n_max = 3, col_names = FALSE, na = c("", "X")) %>%
       t() %>% 
       as_tibble(.name_repair = ~ tempcols) %>% 
-      fill(tempcols) %>% 
+      fill(all_of(tempcols)) %>% 
       unite(sheet_col_names) %>% 
       mutate(sheet_col_names = mutate_col_names(sheet_col_names)) %>%
       select(sheet_col_names) %>% 

--- a/fam-clean.R
+++ b/fam-clean.R
@@ -96,6 +96,18 @@ tidy_tax_fam <- function(sheet, path, filter_BC = TRUE) {
                  str_detect(`place|name|geo`, "NUNAVUT", negate = TRUE)
         )
     }
+    
+    if (any(names(tidy_df) == "place|name")) {
+      tidy_df <- tidy_df %>% 
+        mutate(`place|name` = iconv(`place|name`, from = "latin1", to = "ASCII//TRANSLIT")) %>% 
+        filter(str_detect(`place|name`, "YUKON", negate = TRUE) & ## filtering out territories and those cities
+                 str_detect(`place|name`, "WHITEHORSE", negate = TRUE) &
+                 str_detect(`place|name`, "NORTHWEST", negate = TRUE) &
+                 str_detect(`place|name`, "YELLOWKNIFE", negate = TRUE) &
+                 str_detect(`place|name`, "IQALUIT", negate = TRUE) &
+                 str_detect(`place|name`, "NUNAVUT", negate = TRUE)
+        )
+    }
   }
   
   # clean out the extra decimal places introduced by reading xls into R

--- a/fam-clean.R
+++ b/fam-clean.R
@@ -70,15 +70,32 @@ tidy_tax_fam <- function(sheet, path, filter_BC = TRUE) {
                .name_repair = "unique", na = c("", "X")) %>%
     tibble::add_column(year = file_year, .before = 1) 
   
-  if(filter_BC == TRUE){
-      #filter out only BC Geographies
-      tidy_df <- tidy_df %>% filter(str_detect(`postal|area`, "^V") |
-                                      str_detect(`postal|area`, "^9") | 
-                                      str_detect(`postal|area`, "^59[0-9]{3}") & `level|of|geo` == "31" |
-                                      str_detect(`postal|area`, "^59[0-9]{4}") & `level|of|geo` == "21" | 
-                                      str_detect(`postal|area`, "^515[0-9]{3}") & `level|of|geo` == "51" |
-                                      `level|of|geo` == "11" |
-                                      `level|of|geo` == "12") 
+  #filter out only BC Geographies
+  if (filter_BC == TRUE) {
+    # filter out only BC Geographies
+    tidy_df <- tidy_df %>%
+      filter(str_detect(`postal|area`, "^V") |
+               str_detect(`postal|area`, "^9") |
+               str_detect(`postal|area`, "^59[0-9]{3}") & `level|of|geo` == "31" |
+               str_detect(`postal|area`, "^59[0-9]{2}") & `level|of|geo` == "21" |
+               str_detect(`postal|area`, "^59[0-9]{4}") & `level|of|geo` == "21" |
+               str_detect(`postal|area`, "^515[0-9]{3}") & `level|of|geo` == "51" |
+               `level|of|geo` == "11" |
+               `level|of|geo` == "12") 
+    
+    
+    if (any(names(tidy_df) == "place|name|geo")) {
+      
+      tidy_df <- tidy_df %>% 
+        mutate(`place|name|geo` = iconv(`place|name|geo`, from = "latin1", to = "ASCII//TRANSLIT")) %>% 
+        filter(str_detect(`place|name|geo`, "YUKON", negate = TRUE) & ## filtering out territories and those cities
+                 str_detect(`place|name|geo`, "WHITEHORSE", negate = TRUE) &
+                 str_detect(`place|name|geo`, "NORTHWEST", negate = TRUE) &
+                 str_detect(`place|name|geo`, "YELLOWKNIFE", negate = TRUE) &
+                 str_detect(`place|name|geo`, "IQALUIT", negate = TRUE) &
+                 str_detect(`place|name|geo`, "NUNAVUT", negate = TRUE)
+        )
+    }
   }
   
   # clean out the extra decimal places introduced by reading xls into R

--- a/fam-clean.R
+++ b/fam-clean.R
@@ -167,7 +167,7 @@ clean_taxfiles_fam <- function(input_folder, tidy_folder, filter_BC = TRUE) {
 merge_taxfiles_fam <- function(tidy_folder, output_folder) {
   sub_folders <- get_sub_folders(tidy_folder) 
   for (sub_folder in sub_folders[-1]) {
-    merged_taxfile <- merge_subfolder(sub_folder)
+    merged_taxfile <- merge_subfolder_fam(sub_folder)
     write_csv(merged_taxfile, paste0(output_folder, "/", basename(sub_folder), "_FAM.csv"),  na = "X")
   }
 }

--- a/ind-clean-13.R
+++ b/ind-clean-13.R
@@ -67,7 +67,7 @@ tidy_tax_i13sheet <- function(sheet, skip, col_names, path, filter_BC = TRUE) {
                `level|of|geo` == "11" |
                `level|of|geo` == "12") 
     
-    
+    browser()
     if (any(names(tidy_df) == "place|name|geo")) {
       
       tidy_df <- tidy_df %>% 
@@ -78,6 +78,18 @@ tidy_tax_i13sheet <- function(sheet, skip, col_names, path, filter_BC = TRUE) {
                  str_detect(`place|name|geo`, "YELLOWKNIFE", negate = TRUE) &
                  str_detect(`place|name|geo`, "IQALUIT", negate = TRUE) &
                  str_detect(`place|name|geo`, "NUNAVUT", negate = TRUE)
+        )
+    }
+    
+    if (any(names(tidy_df) == "place|name")) {
+      tidy_df <- tidy_df %>% 
+        mutate(`place|name` = iconv(`place|name`, from = "latin1", to = "ASCII//TRANSLIT")) %>% 
+        filter(str_detect(`place|name`, "YUKON", negate = TRUE) & ## filtering out territories and those cities
+                 str_detect(`place|name`, "WHITEHORSE", negate = TRUE) &
+                 str_detect(`place|name`, "NORTHWEST", negate = TRUE) &
+                 str_detect(`place|name`, "YELLOWKNIFE", negate = TRUE) &
+                 str_detect(`place|name`, "IQALUIT", negate = TRUE) &
+                 str_detect(`place|name`, "NUNAVUT", negate = TRUE)
         )
     }
   }

--- a/ind-clean-13.R
+++ b/ind-clean-13.R
@@ -54,15 +54,32 @@ tidy_tax_i13sheet <- function(sheet, skip, col_names, path, filter_BC = TRUE) {
                .name_repair = "unique", na = c("", "X")) %>%
     tibble::add_column(year = sheet, .before = 1) 
   
-  if (filter_BC == TRUE){
-     #filter out only BC Geographies
-     tidy_df <- tidy_df %>% filter(str_detect(`postal|area`, "^V") |
-                                     str_detect(`postal|area`, "^9") | 
-                                     str_detect(`postal|area`, "^59[0-9]{3}") & `level|of|geo` == "31" |
-                                     str_detect(`postal|area`, "^59[0-9]{4}") & `level|of|geo` == "21" | 
-                                     str_detect(`postal|area`, "^515[0-9]{3}") & `level|of|geo` == "51" |
-                                     `level|of|geo` == "11" |
-                                     `level|of|geo` == "12") 
+  #filter out only BC Geographies
+  if (filter_BC == TRUE) {
+    # filter out only BC Geographies
+    tidy_df <- tidy_df %>%
+      filter(str_detect(`postal|area`, "^V") |
+               str_detect(`postal|area`, "^9") |
+               str_detect(`postal|area`, "^59[0-9]{3}") & `level|of|geo` == "31" |
+               str_detect(`postal|area`, "^59[0-9]{2}") & `level|of|geo` == "21" |
+               str_detect(`postal|area`, "^59[0-9]{4}") & `level|of|geo` == "21" |
+               str_detect(`postal|area`, "^515[0-9]{3}") & `level|of|geo` == "51" |
+               `level|of|geo` == "11" |
+               `level|of|geo` == "12") 
+    
+    
+    if (any(names(tidy_df) == "place|name|geo")) {
+      
+      tidy_df <- tidy_df %>% 
+        mutate(`place|name|geo` = iconv(`place|name|geo`, from = "latin1", to = "ASCII//TRANSLIT")) %>% 
+        filter(str_detect(`place|name|geo`, "YUKON", negate = TRUE) & ## filtering out territories and those cities
+                 str_detect(`place|name|geo`, "WHITEHORSE", negate = TRUE) &
+                 str_detect(`place|name|geo`, "NORTHWEST", negate = TRUE) &
+                 str_detect(`place|name|geo`, "YELLOWKNIFE", negate = TRUE) &
+                 str_detect(`place|name|geo`, "IQALUIT", negate = TRUE) &
+                 str_detect(`place|name|geo`, "NUNAVUT", negate = TRUE)
+        )
+    }
   }
   
   # clean out the extra decimal places introduced by reading xls into R

--- a/ind-clean.R
+++ b/ind-clean.R
@@ -130,7 +130,8 @@ tidy_tax_ind <- function(sheet, path, filter_BC = TRUE) {
                  col_names = sheetcolnames,
                  .name_repair = "unique", na = c("", "X")) %>%
       remove_empty("rows") %>% 
-      tibble::add_column(year = file_year, .before = 1)  
+      tibble::add_column(year = file_year, .before = 1) %>% 
+      mutate(`place|name|geo` = iconv(`place|name|geo`, from = "latin1", to = "ASCII//TRANSLIT"))
   }
   
   #filter out only BC Geographies

--- a/ind-clean.R
+++ b/ind-clean.R
@@ -42,7 +42,7 @@ tidy_tax_ind <- function(sheet, path, filter_BC = TRUE) {
       t() %>% 
       as_tibble(.name_repair = ~ tempcols) %>% 
       slice(1:(n()-2)) %>%
-      fill(tempcols) %>% 
+      fill(all_of(tempcols)) %>% 
       unite(sheet_col_names) %>% 
       mutate(sheet_col_names = mutate_col_names(sheet_col_names)) %>%
       select(sheet_col_names) %>%
@@ -102,7 +102,7 @@ tidy_tax_ind <- function(sheet, path, filter_BC = TRUE) {
       read_excel(sheet = sheet, skip = 1, n_max = 3, col_names = FALSE, na = c("", "X")) %>%
       t() %>% 
       as_tibble(.name_repair = ~ tempcols) %>% 
-      fill(tempcols) %>% 
+      fill(all_of(tempcols)) %>% 
       unite(sheet_col_names) %>% 
       mutate(sheet_col_names = mutate_col_names(sheet_col_names)) %>%
       mutate(sheet_col_names = str_replace(sheet_col_names, "l.o.g.", "level|of|geo")) %>% 

--- a/ind-clean.R
+++ b/ind-clean.R
@@ -32,7 +32,7 @@ tidy_tax_ind <- function(sheet, path, filter_BC = TRUE) {
 
   
   #process sheet 7A-7C differently for years 2002:2006
-  if (file_year %in% messy_years & sheet %in% messy_tables)   {
+  if (file_year %in% messy_years && sheet %in% messy_tables) {
     
     # process sheet 7A,B,C for some years as necessary 
     sheet %in% c("7A", "7B", "7C")

--- a/ind-clean.R
+++ b/ind-clean.R
@@ -130,11 +130,10 @@ tidy_tax_ind <- function(sheet, path, filter_BC = TRUE) {
                  col_names = sheetcolnames,
                  .name_repair = "unique", na = c("", "X")) %>%
       remove_empty("rows") %>% 
-      tibble::add_column(year = file_year, .before = 1) %>% 
-      mutate(`place|name|geo` = iconv(`place|name|geo`, from = "latin1", to = "ASCII//TRANSLIT"))
+      tibble::add_column(year = file_year, .before = 1) 
   }
   
-  #filter out only BC Geographies
+#filter out only BC Geographies
 if (filter_BC == TRUE) {
   # filter out only BC Geographies
   tidy_df <- tidy_df %>%
@@ -145,14 +144,21 @@ if (filter_BC == TRUE) {
       str_detect(`postal|area`, "^59[0-9]{4}") & `level|of|geo` == "21" |
       str_detect(`postal|area`, "^515[0-9]{3}") & `level|of|geo` == "51" |
       `level|of|geo` == "11" |
-      `level|of|geo` == "12") %>%
-    filter(str_detect(`place|name|geo`, "YUKON", negate = TRUE) & ## filtering out territories and those cities
+      `level|of|geo` == "12") 
+  
+  
+  if (any(names(tidy_df) == "place|name|geo")) {
+
+    tidy_df <- tidy_df %>% 
+      mutate(`place|name|geo` = iconv(`place|name|geo`, from = "latin1", to = "ASCII//TRANSLIT")) %>% 
+      filter(str_detect(`place|name|geo`, "YUKON", negate = TRUE) & ## filtering out territories and those cities
              str_detect(`place|name|geo`, "WHITEHORSE", negate = TRUE) &
              str_detect(`place|name|geo`, "NORTHWEST", negate = TRUE) &
              str_detect(`place|name|geo`, "YELLOWKNIFE", negate = TRUE) &
              str_detect(`place|name|geo`, "IQALUIT", negate = TRUE) &
              str_detect(`place|name|geo`, "NUNAVUT", negate = TRUE)
              )
+  }
 }
   
  

--- a/ind-clean.R
+++ b/ind-clean.R
@@ -26,7 +26,7 @@ messy_tables <- c("7A", "7B", "7C")
 ## Tax data tidying function for individual tables:
 
 tidy_tax_ind <- function(sheet, path, filter_BC = TRUE) {
-  
+
   print(paste0("processing ", sheet, " of ", path))
   file_year <- get_file_year(path)
 
@@ -96,7 +96,7 @@ tidy_tax_ind <- function(sheet, path, filter_BC = TRUE) {
     #process sheet 3A, 3B, 3C, 9 and other sheets/clean column headers
     if (sheet %in% c("3A", "3B", "3C", "9")) {
       tempcols <- c("one", "two") 
-    } else tempcols <- c("one", "two", "three")
+    } else {tempcols <- c("one", "two", "three")}
     
     sheetcolnames <- path %>%
       read_excel(sheet = sheet, skip = 1, n_max = 3, col_names = FALSE, na = c("", "X")) %>%

--- a/ind-clean.R
+++ b/ind-clean.R
@@ -134,16 +134,6 @@ tidy_tax_ind <- function(sheet, path, filter_BC = TRUE) {
   }
   
   #filter out only BC Geographies
-  if(filter_BC == TRUE){
-    #filter out only BC Geographies
-    tidy_df <- tidy_df %>% filter(str_detect(`postal|area`, "^V") |
-                                    str_detect(`postal|area`, "^9") | 
-                                    str_detect(`postal|area`, "^59[0-9]{3}") & `level|of|geo` == "31" |
-                                    str_detect(`postal|area`, "^59[0-9]{4}") & `level|of|geo` == "21" | 
-                                    str_detect(`postal|area`, "^515[0-9]{3}") & `level|of|geo` == "51" |
-                                    `level|of|geo` == "11" |
-                                    `level|of|geo` == "12") 
-  }
 if (filter_BC == TRUE) {
   # filter out only BC Geographies
   tidy_df <- tidy_df %>%
@@ -155,6 +145,14 @@ if (filter_BC == TRUE) {
       str_detect(`postal|area`, "^515[0-9]{3}") & `level|of|geo` == "51" |
       `level|of|geo` == "11" |
       `level|of|geo` == "12") %>%
+    filter(str_detect(`place|name|geo`, "YUKON", negate = TRUE) & ## filtering out territories and those cities
+             str_detect(`place|name|geo`, "WHITEHORSE", negate = TRUE) &
+             str_detect(`place|name|geo`, "NORTHWEST", negate = TRUE) &
+             str_detect(`place|name|geo`, "YELLOWKNIFE", negate = TRUE) &
+             str_detect(`place|name|geo`, "IQALUIT", negate = TRUE) &
+             str_detect(`place|name|geo`, "NUNAVUT", negate = TRUE)
+             )
+}
   
  
   # clean out the extra decimal places added by excel

--- a/ind-clean.R
+++ b/ind-clean.R
@@ -131,7 +131,7 @@ tidy_tax_ind <- function(sheet, path, filter_BC = TRUE) {
   }
   
  
-  # clean out the extra decimal places introduced by reading xls into R
+  # clean out the extra decimal places added by excel
   tidy_df1 <- tidy_df %>%
     filter(`level|of|geo` == 61) %>%
     mutate(`postal|area` = formatC(as.numeric(`postal|area`), format="f", digits=2))

--- a/ind-clean.R
+++ b/ind-clean.R
@@ -148,7 +148,6 @@ if (filter_BC == TRUE) {
   
   
   if (any(names(tidy_df) == "place|name|geo")) {
-
     tidy_df <- tidy_df %>% 
       mutate(`place|name|geo` = iconv(`place|name|geo`, from = "latin1", to = "ASCII//TRANSLIT")) %>% 
       filter(str_detect(`place|name|geo`, "YUKON", negate = TRUE) & ## filtering out territories and those cities
@@ -158,6 +157,18 @@ if (filter_BC == TRUE) {
              str_detect(`place|name|geo`, "IQALUIT", negate = TRUE) &
              str_detect(`place|name|geo`, "NUNAVUT", negate = TRUE)
              )
+  }
+  
+  if (any(names(tidy_df) == "place|name")) {
+    tidy_df <- tidy_df %>% 
+      mutate(`place|name` = iconv(`place|name`, from = "latin1", to = "ASCII//TRANSLIT")) %>% 
+      filter(str_detect(`place|name`, "YUKON", negate = TRUE) & ## filtering out territories and those cities
+               str_detect(`place|name`, "WHITEHORSE", negate = TRUE) &
+               str_detect(`place|name`, "NORTHWEST", negate = TRUE) &
+               str_detect(`place|name`, "YELLOWKNIFE", negate = TRUE) &
+               str_detect(`place|name`, "IQALUIT", negate = TRUE) &
+               str_detect(`place|name`, "NUNAVUT", negate = TRUE)
+      )
   }
 }
   

--- a/ind-clean.R
+++ b/ind-clean.R
@@ -144,6 +144,17 @@ tidy_tax_ind <- function(sheet, path, filter_BC = TRUE) {
                                     `level|of|geo` == "11" |
                                     `level|of|geo` == "12") 
   }
+if (filter_BC == TRUE) {
+  # filter out only BC Geographies
+  tidy_df <- tidy_df %>%
+    filter(str_detect(`postal|area`, "^V") |
+      str_detect(`postal|area`, "^9") |
+      str_detect(`postal|area`, "^59[0-9]{3}") & `level|of|geo` == "31" |
+      str_detect(`postal|area`, "^59[0-9]{2}") & `level|of|geo` == "21" |
+      str_detect(`postal|area`, "^59[0-9]{4}") & `level|of|geo` == "21" |
+      str_detect(`postal|area`, "^515[0-9]{3}") & `level|of|geo` == "51" |
+      `level|of|geo` == "11" |
+      `level|of|geo` == "12") %>%
   
  
   # clean out the extra decimal places added by excel

--- a/ind-clean.R
+++ b/ind-clean.R
@@ -212,8 +212,11 @@ clean_taxfiles_ind <- function(input_folder, tidy_folder, filter_BC = TRUE) {
 
 merge_taxfiles_ind <- function(tidy_folder, output_folder) {
   sub_folders <- get_sub_folders(tidy_folder) 
-  for (sub_folder in sub_folders[-1]) {
-    merged_taxfile <- merge_subfolder(sub_folder)
+  ## remove main directory AND 13 dir. That is handled by a separate process
+  sub_folders <- sub_folders[!sub_folders %in% c("data-tidy/ind", "data-tidy/ind/13")]
+  
+  for (sub_folder in sub_folders) {
+    merged_taxfile <- merge_subfolder_ind(sub_folder)
     write_csv(merged_taxfile, paste0(output_folder, "/", basename(sub_folder), "_IND.csv"), na = "X")
   }
 }

--- a/run-all.R
+++ b/run-all.R
@@ -27,11 +27,11 @@ clean_taxfiles_fam("data-raw/fam", "data-tidy/fam")
 merge_taxfiles_fam("data-tidy/fam", "data-output")
 
 
-
 # Individual --------------------------------------------------------------
 
 source("ind-clean.R")
 
+## This exclude IND-13 which takes place inside this function
 ## Calling function for cleaning taxfiles
 clean_taxfiles_ind("data-raw/ind", "data-tidy/ind")
 
@@ -48,13 +48,18 @@ clean_taxfiles_13("data-raw/ind13", "data-tidy/ind13")
 
 ## Map over tidy sheets and bind rows to make one Table 13
 ## Write out IND Table 13 CSV
-
 ind13_path <- here("data-tidy/ind13")   
-ind13_files <- dir(ind13_path, pattern = "*.csv") 
+ind13_files <- list.files(ind13_path, pattern = "*.csv", full.names = TRUE) 
 
-table13 <- ind13_files %>%
-  map(~ read_csv(file.path(ind13_path, .))) %>% 
-  reduce(rbind)
+table13 <- map_df(
+  ind13_files,
+  ~read_csv(.x,
+    col_types = cols(
+      `postal|area` = col_character(),
+      `place|name` = col_character(),
+      .default = col_double()
+    ), na = c("", "NA", "X"))
+  ) 
 
 write_csv(table13, here("data-output/13_IND.csv"),  na = "X")
 


### PR DESCRIPTION
The most consequential part here is using `readr`'s ability to set column classes directly which then result is correctly merge the files. The other element is replacing `rbind.fill` and `lapply` + `do.call()` to just use `map_df`. This is safer since we have the step where we write to disk then read back into R. 